### PR TITLE
apply patch to revert 5d4e2ecfc92d5a2ec3758dec2ae1085f15064480

### DIFF
--- a/src/manager/server_context.cpp
+++ b/src/manager/server_context.cpp
@@ -161,7 +161,9 @@ namespace xios
   
   void CServerContext::sendNotification(int rank)
   {
-    winNotify_->pushToExclusiveWindow(rank, this, &CServerContext::notificationsDumpOut) ;
+    winNotify_->lockWindowExclusive(rank) ;
+    winNotify_->pushToLockedWindow(rank, this, &CServerContext::notificationsDumpOut) ; 
+    winNotify_->unlockWindow(rank) ; 
   }
 
   
@@ -200,7 +202,9 @@ namespace xios
       {
         int commRank ;
         MPI_Comm_rank(contextComm_, &commRank) ;
-        winNotify_->popFromExclusiveWindow(commRank, this, &CServerContext::notificationsDumpIn) ;
+        winNotify_->lockWindowExclusive(commRank) ;
+        winNotify_->popFromLockedWindow(commRank, this, &CServerContext::notificationsDumpIn) ;
+        winNotify_->unlockWindow(commRank) ;
        
         if (notifyInType_!= NOTIFY_NOTHING)
         {

--- a/src/manager/servers_ressource.cpp
+++ b/src/manager/servers_ressource.cpp
@@ -87,7 +87,9 @@ namespace xios
 
   void CServersRessource::sendNotification(int rank)
   {
-    winNotify_->pushToExclusiveWindow(rank, this, &CServersRessource::notificationsDumpOut) ;
+    winNotify_->lockWindow(rank,0) ;
+    winNotify_->pushToWindow(rank, this, &CServersRessource::notificationsDumpOut) ;
+    winNotify_->unlockWindow(rank,0) ;
   }
 
 
@@ -189,7 +191,9 @@ namespace xios
   {
     int commRank ;
     MPI_Comm_rank(serverComm_, &commRank) ;
-    winNotify_->popFromExclusiveWindow(commRank, this, &CServersRessource::notificationsDumpIn) ;
+    winNotify_->lockWindow(commRank,0) ;
+    winNotify_->popFromWindow(commRank, this, &CServersRessource::notificationsDumpIn) ;
+    winNotify_->unlockWindow(commRank,0) ;
     if (notifyInType_==NOTIFY_CREATE_POOL) 
     {
       if (CThreadManager::isUsingThreads()) synchronize() ;

--- a/src/manager/window_manager.cpp
+++ b/src/manager/window_manager.cpp
@@ -6,11 +6,11 @@
 namespace xios
 {
   
-    const MPI_Aint CWindowManager::OFFSET_LOCK ;
-    const int CWindowManager::SIZE_LOCK ;
-    const MPI_Aint CWindowManager::OFFSET_BUFFER_SIZE ;
-    const int CWindowManager::SIZE_BUFFER_SIZE ;
-    const MPI_Aint CWindowManager::OFFSET_BUFFER;
-    const int CWindowManager::WINDOWS_LOCKED ;
+//    const MPI_Aint CWindowManager::OFFSET_LOCK ;
+//    const int CWindowManager::SIZE_LOCK ;
+//    const MPI_Aint CWindowManager::OFFSET_BUFFER_SIZE ;
+//    const int CWindowManager::SIZE_BUFFER_SIZE ;
+//    const MPI_Aint CWindowManager::OFFSET_BUFFER;
+//    const int CWindowManager::WINDOWS_LOCKED ;
 }
 

--- a/xios_test_suite/TEST_SUITE/iodef.xml
+++ b/xios_test_suite/TEST_SUITE/iodef.xml
@@ -49,6 +49,7 @@
       <variable_group id="buffer">
   <variable id="min_buffer_size" type="int">10000000</variable>
   <variable id="optimal_buffer_size" type="string">performance</variable>
+  <variable id="transport_protocol" type="string" >p2p</variable>
   <!--variable id="buffer_factor_size" type="double">0.8</variable-->
       </variable_group>
 

--- a/xios_test_suite/TEST_SUITE/test_domain_algo/checkfile.def
+++ b/xios_test_suite/TEST_SUITE/test_domain_algo/checkfile.def
@@ -2,7 +2,6 @@
 
 atm_output_domain_transformation_reorder.nc
 atm_output_domain_transformation_extract.nc
-atm_output_domain_transformation_zoom.nc
 atm_output_domain_transformation_interpolate.nc
 atm_output_domain_transformation_expand.nc
 


### PR DESCRIPTION
experiment to explore openMPI 
`SIGSEGV: Segmentation fault - invalid memory reference.`

issues with debian/ubuntu openmpi build